### PR TITLE
Adicionar suporte a cobertura de testes localmente com o simplecov

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 if ENV['SIMPLECOV'] == 'simplecov'
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start 'rails'
 else
   require 'coveralls'
   Coveralls.wear!('rails')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,13 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
-require 'coveralls'
-Coveralls.wear!('rails')
+if ENV['SIMPLECOV'] == 'simplecov'
+  require 'simplecov'
+  SimpleCov.start
+else
+  require 'coveralls'
+  Coveralls.wear!('rails')
+end
+
 require 'rails/test_help'
 
 class ActionController::TestCase


### PR DESCRIPTION
Saida: 

``` bash
fabiosammy@fabiosammy-dell:~/Desenvolvimento/aulas/tickets$ bash bin/docker_run /bin/bash
I have no name!@2338f0daf721:/app$ RAILS_ENV=test SIMPLECOV=simplecov rake test
Run options: --seed 8610

# Running:

..........................................

Finished in 0.642804s, 65.3388 runs/s, 108.8980 assertions/s.

42 runs, 70 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for MiniTest to /app/coverage. 3869 / 6923 LOC (55.89%) covered.
I have no name!@2338f0daf721:/app$ ls coverage/
assets  index.html
I have no name!@2338f0daf721:/app$ 
```

Resultado:
![captura de tela de 2016-05-30 19 03 32](https://cloud.githubusercontent.com/assets/972184/15658945/528ff15c-2699-11e6-8f2c-fe2dfee75da7.png)
